### PR TITLE
Feature/adding plugins

### DIFF
--- a/packages/analytics-core/src/index.js
+++ b/packages/analytics-core/src/index.js
@@ -9,7 +9,7 @@ import EVENTS, { coreEvents, nonEvents, isReservedAction } from './events'
 import * as middleware from './middleware'
 import DynamicMiddleware from './middleware/dynamic'
 // Modules
-import pluginsMiddleware from './modules/plugins'
+import pluginsMiddleware, { initializePluginState } from './modules/plugins'
 import track from './modules/track'
 import queue from './modules/queue'
 import page, { getPageData } from './modules/page'
@@ -62,32 +62,26 @@ function analytics(config = {}) {
   // if (SERVER) {
   //   console.log('INIT SERVER')
   // }
-  
+
   /* Parse plugins array */
   const parsedOptions = (config.plugins || []).reduce((acc, plugin) => {
     if (isFunction(plugin)) {
       /* Custom redux middleware */
-      acc.middlewares = acc.middlewares.concat(plugin)
-      return acc
+      acc.middlewares = acc.middlewares.concat(plugin);
+      return acc;
     }
     // Legacy plugin with name
-    if (plugin.NAMESPACE) plugin.name = plugin.NAMESPACE
-    if (!plugin.name) {
-      /* Plugins must supply a "name" property. See error url for more details */
-      throw new Error(ERROR_URL + '1')
-    }
+    // if (plugin.NAMESPACE) plugin.name = plugin.NAMESPACE;
+    // if (!plugin.name) {
+    //   /* Plugins must supply a "name" property. See error url for more details */
+    //   throw new Error(ERROR_URL + "1");
+    // }
     // Set config if empty
-    if (!plugin.config) plugin.config = {}
+    // if (!plugin.config) plugin.config = {};
     // if plugin exposes EVENTS capture available events
     const definedEvents = (plugin.EVENTS) ? Object.keys(plugin.EVENTS).map((k) => {
       return plugin.EVENTS[k]
     }) : []
-
-    const enabledFromMerge = !(plugin.enabled === false)
-    const enabledFromPluginConfig = !(plugin.config.enabled === false)
-    // top level { enabled: false } takes presidence over { config: enabled: false }
-    acc.pluginEnabled[plugin.name] = enabledFromMerge && enabledFromPluginConfig
-    delete plugin.enabled
 
     if (plugin.methods) {
       acc.methods[plugin.name] = Object.keys(plugin.methods).reduce((a, c) => {
@@ -96,8 +90,18 @@ function analytics(config = {}) {
         return a
       }, {})
       // Remove additional methods from plugins
-      delete plugin.methods
+      plugin.methods = undefined;
     }
+
+    const convertedPlugin = initializePluginState(plugin);
+
+    // const enabledFromMerge = !(plugin.enabled === false);
+    // const enabledFromPluginConfig = !(plugin.config.enabled === false);
+    // top level { enabled: false } takes presidence over { config: enabled: false }
+    // The check for presidence of enabled is done within initializePluginState
+    acc.pluginEnabled[plugin.name] = plugin.enabled;
+    plugin.enabled = undefined;
+
     // Convert available methods into events
     const methodsToEvents = Object.keys(plugin)
     // Combine events
@@ -111,11 +115,8 @@ function analytics(config = {}) {
     if (acc.plugins[plugin.name]) {
       throw new Error(plugin.name + 'AlreadyLoaded')
     }
-    acc.plugins[plugin.name] = plugin
-    if (!acc.plugins[plugin.name].loaded) {
-      // set default loaded func
-      acc.plugins[plugin.name].loaded = () => true
-    }
+
+    acc.plugins[plugin.name] = convertedPlugin
     return acc
   }, {
     plugins: {},
@@ -258,23 +259,53 @@ function analytics(config = {}) {
       })
     },
     */
-    /* @TODO if it stays, state loaded needs to be set. Re PLUGIN_INIT above
-    add: (newPlugin) => {
-      if (typeof newPlugin !== 'object') return false
-      // Set on global integration object
-      customPlugins = Object.assign({}, customPlugins, {
-        [`${newPlugin.name}`]: newPlugin
+    // @TODO if it stays, state loaded needs to be set. Re PLUGIN_INIT above
+    /**
+     * Add analytics plugin
+     * @typedef {Function} AddPlugin
+     * @param {AnalyticsPlugin} newPlugin
+     * @returns
+     */
+    add: (newPlugin, callback) => {
+      return new Promise((res) => {
+        if (typeof newPlugin !== "object") res(false)
+
+        const initializedNewPlugin = initializePluginState(newPlugin)
+        // Set on global integration object
+        customPlugins = Object.assign({}, customPlugins, {
+          [`${initializedNewPlugin.name}`]: initializedNewPlugin
+        })
+
+        // Object.assign(this, pluginMethods);
+
+        // then add it, and init state key
+        store.dispatch({
+          type: EVENTS.registerPluginType(initializedNewPlugin.name),
+          name: initializedNewPlugin.name,
+          enabled: initializedNewPlugin.enabled,
+          plugin: initializedNewPlugin,
+        })
+
+        if (initializedNewPlugin.enabled) {
+          store.dispatch(
+            {
+              type: EVENTS.enablePlugin,
+              plugins: [initializedNewPlugin.name],
+              _: { originalAction: EVENTS.enablePlugin }
+            },
+            res,
+            [callback]
+          )
+        } else {
+          // Since the plugin was not enabled just want to confirm it was added
+          callback && callback(true)
+          res(true)
+        }
       })
-      // then add it, and init state key
-      store.dispatch({
-        type: EVENTS.pluginRegister,
-        name: newPlugin.name,
-        plugin: newPlugin
-      })
-    }, */
+    },
     // Merge in custom plugin methods
-    ...parsedOptions.methods
-  }
+    ...parsedOptions.methods,
+  };
   
   let readyCalled = false
   /**
@@ -294,48 +325,48 @@ function analytics(config = {}) {
    */
   const instance = {
     /**
-    * Identify a user. This will trigger `identify` calls in any installed plugins and will set user data in localStorage
-    * @typedef {Function} Identify
-    * @param  {String}   userId  - Unique ID of user
-    * @param  {Object}   [traits]  - Object of user traits
-    * @param  {Object}   [options] - Options to pass to identify call
-    * @param  {Function} [callback] - Callback function after identify completes
-    * @returns {Promise}
-    * @api public
-    *
-    * @example
-    *
-    * // Basic user id identify
-    * analytics.identify('xyz-123')
-    *
-    * // Identify with additional traits
-    * analytics.identify('xyz-123', {
-    *   name: 'steve',
-    *   company: 'hello-clicky'
-    * })
-    *
-    * // Fire callback with 2nd or 3rd argument
-    * analytics.identify('xyz-123', () => {
-    *   console.log('do this after identify')
-    * })
-    *
-    * // Disable sending user data to specific analytic tools
-    * analytics.identify('xyz-123', {}, {
-    *   plugins: {
-    *     // disable sending this identify call to segment
-    *     segment: false
-    *   }
-    * })
-    *
-    * // Send user data to only to specific analytic tools
-    * analytics.identify('xyz-123', {}, {
-    *   plugins: {
-    *     // disable this specific identify in all plugins except customerio
-    *     all: false,
-    *     customerio: true
-    *   }
-    * })
-    */
+     * Identify a user. This will trigger `identify` calls in any installed plugins and will set user data in localStorage
+     * @typedef {Function} Identify
+     * @param  {String}   userId  - Unique ID of user
+     * @param  {Object}   [traits]  - Object of user traits
+     * @param  {Object}   [options] - Options to pass to identify call
+     * @param  {Function} [callback] - Callback function after identify completes
+     * @returns {Promise}
+     * @api public
+     *
+     * @example
+     *
+     * // Basic user id identify
+     * analytics.identify('xyz-123')
+     *
+     * // Identify with additional traits
+     * analytics.identify('xyz-123', {
+     *   name: 'steve',
+     *   company: 'hello-clicky'
+     * })
+     *
+     * // Fire callback with 2nd or 3rd argument
+     * analytics.identify('xyz-123', () => {
+     *   console.log('do this after identify')
+     * })
+     *
+     * // Disable sending user data to specific analytic tools
+     * analytics.identify('xyz-123', {}, {
+     *   plugins: {
+     *     // disable sending this identify call to segment
+     *     segment: false
+     *   }
+     * })
+     *
+     * // Send user data to only to specific analytic tools
+     * analytics.identify('xyz-123', {}, {
+     *   plugins: {
+     *     // disable this specific identify in all plugins except customerio
+     *     all: false,
+     *     customerio: true
+     *   }
+     * })
+     */
     identify: async (userId, traits, options, callback) => {
       const id = isString(userId) ? userId : null
       const data = isObject(userId) ? userId : traits
@@ -585,7 +616,7 @@ function analytics(config = {}) {
       }
       const startRegex = /Start$|Start:/
       if (name === '*') {
-        const beforeHandler = store => next => action => {
+        const beforeHandler = (store) => (next) => (action) => {
           if (action.type.match(startRegex)) {
             callback({ // eslint-disable-line
               payload: action,
@@ -595,7 +626,7 @@ function analytics(config = {}) {
           }
           return next(action)
         }
-        const afterHandler = store => next => action => {
+        const afterHandler = (store) => (next) => (action) => {
           if (!action.type.match(startRegex)) {
             callback({ // eslint-disable-line
               payload: action,
@@ -876,6 +907,7 @@ function analytics(config = {}) {
   const initialConfig = makeContext(config)
 
   const intialPluginState = parsedOptions.pluginsArray.reduce((acc, plugin) => {
+    console.log(plugin)
     const { name, config, loaded } = plugin
     const isEnabled = parsedOptions.pluginEnabled[name]
     acc[name] = {

--- a/packages/analytics-core/src/modules/plugins.js
+++ b/packages/analytics-core/src/modules/plugins.js
@@ -92,3 +92,28 @@ function togglePluginStatus(plugins, status, currentState) {
     return acc
   }, currentState)
 }
+
+/**
+ * Will create an analytics plugin initial state for the store
+ *
+ * @param {AnalyticsPlugin} plugin
+ *
+ * @returns {AnalyticsPluginState}
+ */
+ export function initializePluginState(plugin) {
+  if (plugin.NAMESPACE) plugin.name = plugin.NAMESPACE
+  if (!plugin.name) {
+    throw new Error(ERROR_URL + "1")
+  }
+  if (!plugin.config) plugin.config = {}
+
+  const enabledFromMerge = plugin.enabled !== false
+  const enabledFromPluginConfig = plugin.config.enabled !== false
+  plugin.enabled = enabledFromMerge && enabledFromPluginConfig
+
+  if (!plugin.loaded) {
+    plugin.loaded = () => true
+  }
+
+  return plugin
+}

--- a/packages/analytics-core/src/modules/plugins.js
+++ b/packages/analytics-core/src/modules/plugins.js
@@ -111,6 +111,8 @@ function togglePluginStatus(plugins, status, currentState) {
   const enabledFromPluginConfig = plugin.config.enabled !== false
   plugin.enabled = enabledFromMerge && enabledFromPluginConfig
 
+  plugin.initialized = plugin.enabled ? Boolean(!plugin.initialize) : false;
+
   if (!plugin.loaded) {
     plugin.loaded = () => true
   }

--- a/packages/analytics-core/src/pluginTypeDef.js
+++ b/packages/analytics-core/src/pluginTypeDef.js
@@ -10,3 +10,11 @@
   * @property {function} [loaded] - Function to determine if analytics script loaded
   * @property {function} [ready] - Fire function when plugin ready
   */
+
+/**
+  * @typedef {Object} AnalyticsPluginState
+  * @property {boolean} enabled
+  * @property {boolean} initialized
+  * @property {boolean} loaded
+  * @property {Object}  config
+  */

--- a/packages/analytics-core/tests/plugins-add.test.js
+++ b/packages/analytics-core/tests/plugins-add.test.js
@@ -1,0 +1,135 @@
+import test from 'ava';
+import Analytics from '../src';
+import sinon from "sinon";
+import delay from './_utils/delay';
+
+test.beforeEach((t) => {
+  t.context.sandbox = sinon.createSandbox();
+})
+
+test("Plugin Added > Disabled add returns true", async (t) => {
+  const analytics = Analytics({ app: 'hello' });
+  const addedPluginResult = await analytics.plugins.add({
+    name: "testing-one-two",
+    enabled: false,
+    track: () => "thing",
+  });
+
+  t.is(addedPluginResult, true);
+});
+
+test("Plugin Added > Invalid plugin return false", async (t) => {
+  const analytics = Analytics({ app: 'hello-failed' });
+  const invalidPluginAdded = await analytics.plugins.add(false);
+
+  t.is(invalidPluginAdded, false);
+});
+
+test("Plugin Added > Loads and Initis", async (t) => {
+  const { context } = t;
+  const spyLoad = context.sandbox.spy(() => true);
+  const spyInit = context.sandbox.spy();
+
+  const analytics = Analytics({ app: "hello-new-plugins" });
+  await analytics.plugins.add({
+    name: "late-to-the-party",
+    enabled: true,
+    loaded: spyLoad,
+    initialize: spyInit,
+  });
+
+  const pluginsState = analytics.getState("plugins");
+
+  t.is(pluginsState["late-to-the-party"].enabled, true);
+  t.is(pluginsState["late-to-the-party"].initialized, true);
+  t.is(spyInit.callCount, 1);
+  t.is(spyLoad.callCount >= 1, true);
+});
+
+test("Plugin Added > Disabled will not", async (t) => {
+  const { context } = t;
+  const spyLoad = context.sandbox.spy(() => true);
+  const spyInit = context.sandbox.spy();
+
+  const analytics = Analytics({
+    app: "hello-disabled"
+  });
+  await analytics.plugins.add({
+    name: "disabled-test",
+    enabled: false,
+    loaded: spyLoad,
+    initialize: spyInit
+  });
+  const pluginsState = analytics.getState("plugins");
+
+  t.is(pluginsState["disabled-test"].enabled, false);
+  t.is(pluginsState["disabled-test"].initialized, false);
+  t.is(pluginsState["disabled-test"].loaded, false);  
+});
+
+// Any delay in a test with async code is a bad idea....
+test("Plugin Added > Register Plugin with add is async", async (t) => {
+  const analytics = Analytics({
+    app: "async-register" // It's not as exciting as it sounds -_-
+  });
+
+  await analytics.plugins.add({
+    name: "async-register",
+    track: () => ""
+  });
+
+  t.is(analytics.getState("plugins.async-register").enabled, true);
+
+  await analytics.plugins.add({
+    name: "async-register-disabled",
+    enabled: false,
+    track: () => ""
+  });
+
+  t.is(analytics.getState("plugins.async-register-disabled").enabled, false);
+});
+
+// Had to hoist state to force control delay on load
+let finishLoading = false;
+test("Plugin Added > Queueded as expected", async (t) => {
+  const analytics = Analytics({
+    app: "queue-test",
+    plugins: [
+      {
+        name: "added",
+        enabled: true,
+        track: () => ""
+      }
+    ]
+  });
+
+  await analytics.plugins.add({
+    name: "late-queue",
+    enabled: true,
+    loaded: () => {
+      return finishLoading;
+    },
+    track: () => {
+      return "";
+    }
+  });
+
+  await analytics.track("random");
+  await analytics.track("random");
+  await analytics.track("random");
+
+  // Check for expected queueing
+  const pluginsState = analytics.getState("queue.actions");
+  t.is(pluginsState.length, 3);
+
+  finishLoading = true;
+  // Here the delay is to give the queue time to drain
+  await delay(100);
+
+  // Check if drains successfully
+  const drainedPluginsState = analytics.getState();
+  t.is(drainedPluginsState.queue.actions.length, 0);
+  t.is(drainedPluginsState.track.history.length, 3);
+});
+
+test.todo("Plugin Added > Custom events are added to the middleware");


### PR DESCRIPTION
# Description
Add plugins functionality was missing from the library this seeks to remedy that and I would like to explore eventually removing as well. This is done by exploiting already existing systems, but had to change the library to gain access to the plugins object. From there we were able to run away with middlewares and such to create an experience the same as one as if initialized at the start. In addition, thanks to the utilization of middleware we were able to create an async wrapper around the `registerPlugin` event.